### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ buildPlugin(configurations: [
     //[ platform: "windows", jdk: "8", jenkins: null ],
 
     // More recent LTS, only Linux
-    //[ platform: "linux", jdk: "8", jenkins: '2.263.1', javaLevel: "8" ],
+    //[ platform: "linux", jdk: "8", jenkins: '2.263.1' ],
 
     // Checking JDK 11 
     //[ platform: "linux", jdk: "11", jenkins: null ]


### PR DESCRIPTION
The javaLevel option is deprecated and does no longer set the Java version. The option is ignored.
This PR removes the unused option.