### PR TITLE
Remove usage of deprecated IOException2

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/cloverphp/CloverCoverageParser.java
+++ b/src/main/java/org/jenkinsci/plugins/cloverphp/CloverCoverageParser.java
@@ -5,7 +5,6 @@ import org.jenkinsci.plugins.cloverphp.results.ClassCoverage;
 import org.jenkinsci.plugins.cloverphp.results.FileCoverage;
 import org.jenkinsci.plugins.cloverphp.results.PackageCoverage;
 import org.jenkinsci.plugins.cloverphp.results.ProjectCoverage;
-import hudson.util.IOException2;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -92,7 +91,7 @@ public final class CloverCoverageParser {
             }
             return coverage;
         } catch (SAXException e) {
-            throw new IOException2("Cannot parse coverage results", e);
+            throw new IOException("Cannot parse coverage results", e);
         }
     }
 


### PR DESCRIPTION
## Remove usage of deprecated IOException2

Removes usage of deprecated `hudson.util.IOException2` by replacing it with `java.io.IOException`

### Testing done

None, rely on `ci.jenkins.io` to test it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue